### PR TITLE
Fix recursive copy of solr example files

### DIFF
--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -38,7 +38,7 @@
 # Ansible copy doesn't support recusive copy of directories
 - name: Copy solr example files to the new directory
   shell: >
-    cp --recursive -v /tmp/downloads/solr-4.2.0/example/solr "{{ fedora_home }}/solr/"
+    cp --recursive -v /tmp/downloads/solr-4.2.0/example/solr "{{ fedora_home }}"
 
 - name: Copy solr to Tomcat Webapps Directory
   copy:


### PR DESCRIPTION
Specify the destination directory correctly so that we get files at `{{fedora_home}}/solr/` and not `{{fedora_home}}/solr/solr/`
## Motivation and Context

Solr files need to be in the right place. 
## How Has This Been Tested?
