### PR TITLE
Fixed solr install path issue

### DIFF
--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -38,7 +38,7 @@
 # Ansible copy doesn't support recusive copy of directories
 - name: Copy solr example files to the new directory
   shell: >
-    cp --recursive -v /tmp/downloads/solr-4.2.0/example/solr "{{ fedora_home }}/solr/"
+    cp --recursive -v /tmp/downloads/solr-4.2.0/example/solr/* "{{ fedora_home }}/solr/"
 
 - name: Copy solr to Tomcat Webapps Directory
   copy:
@@ -124,17 +124,12 @@
   command: >
     ant -f /usr/share/tomcat/webapps/fedoragsearch/FgsConfig/fgsconfig-basic.xml
 
-- name: Backup original solr schema.xml
-  copy:
-    src: "{{ fedora_home }}/solr/collection1/conf/schema.xml"
-    dest: "{{ fedora_home }}/solr/collection1/conf/schema.bak"
-    remote_src: true
-
 - name: Copy ANT generated schema to schema.xml
   copy:
     src: /usr/share/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/conf/schema-4.2.0-for-fgs-2.7.xml
     dest: "{{ fedora_home }}/solr/collection1/conf/schema.xml"
     remote_src: true
+    backup: yes
 
 - name: Add the Solr context file
   template:


### PR DESCRIPTION
SOLR files copy command would fail as the command copies the directory into the destination directory. Added a /\* on the end of the src path to force ansible to only copy the directory contents.

Also removed the task to Backup Initial Schema.xml and added "backup: yes" to the folllowing task at new Schema creation.
## Motivation and Context

Copy was puting solr dir inside the solr dir so next steps would fail. /usr/local/fedora/solr/solr 
## How Has This Been Tested?

Changes allowed vagrant up to succeed.
