### PR TITLE
Add /uuid/ paths to localhost:80 reverse proxy.

### DIFF
--- a/tasks/islandora.yml
+++ b/tasks/islandora.yml
@@ -68,6 +68,8 @@
        SSLProxyCheckPeerName Off
        ProxyPass /islandora/object https://{{ islandora_site}}.{{ httpd_dn_suffix }}/islandora/object
        ProxyPassReverse /islandora/object https://{{ islandora_site}}.{{ httpd_dn_suffix }}/islandora/object
+       ProxyPass /uuid https://{{ islandora_site}}.{{ httpd_dn_suffix }}/uuid
+       ProxyPassReverse /uuid https://{{ islandora_site}}.{{ httpd_dn_suffix }}/uuid
 
 - name: Restart apache
   service:


### PR DESCRIPTION
## Motivation and Context

We're using pathauto to provide UUID-based URIs. This makes sure that the localhost:80 proxy kludge that we're using for djatoka knows about them. 
## How Has This Been Tested?

Djatoka-provided images stop 404ing when this is applied. 
