### PR TITLE
Copy Drush makefile to remote host

### DIFF
--- a/tasks/djatoka.yml
+++ b/tasks/djatoka.yml
@@ -19,6 +19,7 @@
     dest: "/opt/adore"
     creates: "/opt/adore/adore-djatoka-1.1/README.txt"
     remote_src: yes
+    copy: no
 
 - name: Add symlink at /opt/adore/djatoka
   file:
@@ -32,6 +33,7 @@
     src: "/opt/adore/djatoka/dist/adore-djatoka.war"
     dest: "/usr/share/tomcat/webapps/adore-djatoka.war"
     remote_src: true
+    follow: yes
 
 - name: Configure Tomcat environment
   template:
@@ -55,6 +57,7 @@
     dest: /usr/share/tomcat/webapps/adore-djatoka/WEB-INF/classes/log4j.properties
     owner: tomcat
     group: tomcat
+    follow: yes
 
 - name: Configure Kakadu libraries
   lineinfile:

--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -10,12 +10,14 @@
     src: /tmp/downloads/fedoragsearch-2.7.zip
     dest: /tmp/downloads
     remote_src: yes
+    copy: no
 
 - name: Copy GSearch to Tomcat Webapps Directory
   copy:
     src: "/tmp/downloads/fedoragsearch-2.7/fedoragsearch.war"
     dest: "/usr/share/tomcat/webapps/fedoragsearch.war"
     remote_src: true
+    follow: yes
 
 - name: Download Solr from Apache.org
   get_url:
@@ -28,6 +30,7 @@
     src: /tmp/downloads/solr-4.2.0.tgz
     dest: /tmp/downloads
     remote_src: yes
+    copy: no
 
 - name: Create new directory for fedora
   file:
@@ -49,6 +52,7 @@
     src: /tmp/downloads/solr-4.2.0/dist/solr-4.2.0.war
     dest: /usr/share/tomcat/webapps/solr.war
     remote_src: true
+    follow: yes
 
 - name: Insert "fgsAdmin" user in fedora-users.xml
   blockinfile:
@@ -70,6 +74,7 @@
     src: /usr/share/tomcat/webapps/fedoragsearch/FgsConfig/fgsconfig-basic-for-islandora.properties
     dest: /usr/share/tomcat/webapps/fedoragsearch/FgsConfig/fgsconfig-basic-for-islandora.properties.bak
     remote_src: true
+    follow: yes
 
 - name: Configure fgsconfig-basic-for-islandora.properties
   template:
@@ -82,6 +87,8 @@
   copy:
     src: /usr/share/tomcat/webapps/fedoragsearch/FgsConfig/fgsconfig-basic.xml
     dest: /usr/share/tomcat/webapps/fedoragsearch/FgsConfig/fgsconfig-basic.xml.bak
+    remote_src: true
+    follow: yes
 
 - name: Configure fgsconfig-basic.xml
   replace:
@@ -112,9 +119,10 @@
 - name: Install Ant
   tags: ant
   unarchive:
-    remote_src: yes
     src: /tmp/downloads/apache-ant-1.9.7-bin.tar.gz
     dest: /opt/apache
+    remote_src: yes
+    copy: no
 
 - name: Build link to /usr/bin/ant
   tags: ant
@@ -134,6 +142,7 @@
     dest: "{{ fedora_home }}/solr/collection1/conf/schema.xml"
     remote_src: true
     backup: yes
+    follow: yes
 
 - name: Add the Solr context file
   template:

--- a/tasks/islandora.yml
+++ b/tasks/islandora.yml
@@ -104,7 +104,7 @@
 
 - name: Run  drush make file
   shell: >
-    /opt/d7/bin/d7_make.sh /srv/{{ islandora_site }} /opt/oulib/island/etc/repo.make
+    /opt/d7/bin/d7_make.sh /srv/{{ islandora_site }} file:///opt/oulib/island/etc/repo.make
   ignore_errors: yes
 
 - name: Ensure /opt/oulib/island/bin exists

--- a/tasks/islandora.yml
+++ b/tasks/islandora.yml
@@ -47,6 +47,29 @@
     timeout: 90
     echo: yes
 
+- name: Ensure /opt/oulib/island/etc exists
+  file:
+    path: /opt/oulib/island/etc
+    state: directory
+    mode: 0655
+    owner: root
+    group: wheel
+    recurse: yes
+  tags:
+    - assets
+
+- name: Copy the Islandora Drush makefile
+  copy:
+    src: "{{ item }}"
+    dest: "/opt/oulib/island/etc/repo.make"
+    mode: 0655
+    owner: root
+    group: wheel
+  with_items:
+    - repo.make
+  tags:
+    - assets
+
 - name: Proxy djatoka from tomcat and rewrite rft_id because djatoka is terrible
   blockinfile:
     dest: "/srv/{{ islandora_site }}/etc/srv_{{ islandora_site }}.conf"
@@ -78,7 +101,7 @@
 
 - name: Run  drush make file
   shell: >
-    /opt/d7/bin/d7_make.sh /srv/{{ islandora_site }}  {{ islandora_makefile }}
+    /opt/d7/bin/d7_make.sh /srv/{{ islandora_site }} /opt/oulib/island/etc/repo.make
   ignore_errors: yes
 
 - name: Ensure /opt/oulib/island/bin exists

--- a/tasks/islandora.yml
+++ b/tasks/islandora.yml
@@ -10,6 +10,8 @@
     dest: "/usr/share/tomcat/webapps/fedora/WEB-INF/lib/fcrepo-drupalauthfilter-3.8.1.jar"
     owner: "tomcat"
     group: "tomcat"
+    remote_src: true
+    follow: yes
 
 - name: Let Fedora know aobut the Islandora Drupal Filter
   copy:
@@ -17,6 +19,7 @@
     dest: "{{fedora_home}}/server/config/jaas.conf"
     owner: "tomcat"
     group: "tomcat"
+    follow: yes
 
 - name: Configure the Islandora Drupal Filter
   template:


### PR DESCRIPTION
Adds asset-tagged tasks to copy over drush makefile to an /opt/etc directory.
Drops the islandora_makefile var and hardcodes the ansible-copied makefile location.
## Motivation and Context

Drush make wouldn't work in a non-vagrant environment previously.
https://github.com/OULibraries/ansible-role-d7-islandora/issues/15
## How Has This Been Tested?

many passes of ec2 deployments.
