### PR TITLE
Debug and configure Solr+GSearch service

### DIFF
--- a/files/repo.enable.sh
+++ b/files/repo.enable.sh
@@ -4,7 +4,6 @@ source /opt/d7/etc/d7_conf.sh
 
 ISLANDORA_ROOT="/srv/repository/drupal"
 
-
 # Site and theme basics
 drush -r "$ISLANDORA_ROOT" -y -u 1 en jquery_update bootstrap oulib_repository
 drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('theme_default','oulib_repository')"
@@ -18,6 +17,10 @@ drush -r "$ISLANDORA_ROOT" -y -u 1 en islandora_solr islandora_solr_config
 drush -r "$ISLANDORA_ROOT" -y -u 1 role-add-perm 'anonymous user' 'view fedora repository objects'
 drush -r "$ISLANDORA_ROOT" -y -u 1 role-add-perm 'authenticated user' 'view fedora repository objects'
 
+# We probably want to let everyone do search
+drush -r "$ISLANDORA_ROOT" -y -u 1 role-add-perm 'anonymous user' 'search islandora solr'
+drush -r "$ISLANDORA_ROOT" -y -u 1 role-add-perm 'authenticated user' 'search islandora solr'
+
 # Basic Image and Large Image
 drush -r "$ISLANDORA_ROOT" -y -u 1 en imagemagick islandora_basic_image islandora_large_image islandora_openseadragon
 drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('image_toolkit', 'imagemagick')"
@@ -26,7 +29,7 @@ drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('islandora_use_kakadu', TR
 drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('islandora_kakadu_url', '/usr/local/bin/kdu_compress')"
 drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('islandora_large_image_viewers', array('name' => array('none' => 'none', 'islandora_openseadragon' => 'islandora_openseadragon'), 'default' => 'islandora_openseadragon'))"
 
-# Books 
+# Books
 drush -r "$ISLANDORA_ROOT" -y -u 1 en islandora_paged_content islandora_book islandora_internet_archive_bookreader
 drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('islandora_book_page_viewers', array('name' => array('none' => 'none', 'islandora_openseadragon' => 'islandora_openseadragon'), 'default' => 'islandora_openseadragon'))"
 drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('islandora_book_viewers', array('name' => array('none' => 'none', 'islandora_internet_archive_bookreader' => 'islandora_internet_archive_bookreader'), 'default' => 'islandora_internet_archive_bookreader'))"
@@ -41,4 +44,3 @@ drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('pathauto_islandora_island
 drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('pathauto_islandora_islandora:pageCModel_pattern', '/uuid/[fedora:shortpid]')"
 drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('pathauto_islandora_islandora:sp_large_image_cmodel_pattern', '/uuid/[fedora:shortpid]')"
 drush -r "$ISLANDORA_ROOT" -y -u 1 eval "variable_set('subpathauto_depth', 4)"
-

--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -55,7 +55,7 @@
     marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     dest: /usr/local/fedora/server/config/fedora-users.xml
     block: |
-      <user name="fgsAdmin" password="fgsAdmin">
+      <user name="fgsAdmin" password="{{ gsearch_pass }}">
         <attribute name="fedoraRole">
           <value>administrator</value>
         </attribute>

--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -175,15 +175,3 @@
   wait_for:
     port: 8080
     delay: 10
-
-- name: Run gsearch updateindex from FoxmlFiles
-  uri:
-    url: "http://localhost:8080/fedoragsearch/rest?operation=updateIndex&action=fromFoxmlFiles&value="
-    method: "GET"
-    status_code: 200
-
-- name: Reload Solr core
-  uri:
-    url: "http://localhost:8080/solr/admin/cores?wt=json&action=RELOAD&core=collection1"
-    method: "GET"
-    status_code: 200

--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -5,7 +5,7 @@
     timeout: 90
     dest: "/tmp/downloads/fedoragsearch-2.7.zip"
 
-- name: UnArchive GSearch
+- name: Unzip GSearch
   unarchive:
     src: /tmp/downloads/fedoragsearch-2.7.zip
     dest: /tmp/downloads
@@ -40,7 +40,7 @@
     owner: tomcat
     group: tomcat
 
-# Ansible copy doesn't support recusive copy of directories
+# Ansible copy doesn't support recusive copy of directories yet
 - name: Copy solr example files to the new directory
   become: yes
   become_user: tomcat
@@ -66,7 +66,7 @@
         </attribute>
       </user>
 
-- name: Restart tomcat to deploy GSearch and Solr wars
+- name: Restart Tomcat to deploy GSearch and Solr wars
   service:
     name: "tomcat"
     state: "restarted"
@@ -134,7 +134,7 @@
     # making changes to these files. Probably we should just fork the
     # upstream code in the near future.
 
-- name: Adjust path to Tomcat in solr transforms
+- name: Configure location of Tomcat in Solr transforms
   shell: |
     cd /tmp/downloads/basic-solr-config/islandora_transforms
     sed -i 's#/usr/local/fedora/tomcat#/var/lib/tomcat#g' ./*xslt
@@ -144,14 +144,14 @@
     dest: /tmp/downloads/dgi_gsearch_extensions
     repo: https://github.com/discoverygarden/dgi_gsearch_extensions.git
 
-- name: Get Discovery Garden gsearch extensions
+- name: Build Discovery Garden gsearch extensions
   shell: |
     cd /tmp/downloads/dgi_gsearch_extensions
     /opt/apache/maven/bin/mvn -q package
   args:
     creates: /tmp/downloads/dgi_gsearch_extensions/target/gsearch_extensions-0.1.1-jar-with-dependencies.jar
 
-- name: Deploy dgi_gsearch_extensions
+- name: Deploy Discovery Garden gsearch extensions
   become: true
   become_user: tomcat
   copy:
@@ -159,19 +159,14 @@
     dest: /var/lib/tomcat/webapps/fedoragsearch/WEB-INF/lib
     remote_src: yes
 
-- name: Deploy basic solr config
+- name: Deploy basic Solr config
   become: true
   become_user: tomcat
   shell: |
      cp -v /tmp/downloads/basic-solr-config/conf/*  {{ fedora_home }}/solr/collection1/conf
      cp -Rv /tmp/downloads/basic-solr-config/islandora_transforms /var/lib/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex
 
-- name: Restart tomcat
+- name: Restart Tomcat
   service:
     name: "tomcat"
     state: "restarted"
-
-- name: Wait for tomcat to restart
-  wait_for:
-    port: 8080
-    delay: 10

--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -54,6 +54,7 @@
   blockinfile:
     marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     dest: /usr/local/fedora/server/config/fedora-users.xml
+    insertbefore: </users>
     block: |
       <user name="fgsAdmin" password="{{ gsearch_pass }}">
         <attribute name="fedoraRole">
@@ -92,42 +93,9 @@
     replace: >
       \1fgsconfig-basic-for-islandora.properties\2
 
-- name: Download Ant
-  tags: ant
-  get_url:
-    url: http://mirror.ox.ac.uk/sites/rsync.apache.org/ant/binaries/apache-ant-1.9.7-bin.tar.gz
-    dest: /tmp/downloads/apache-ant-1.9.7-bin.tar.gz
-    owner: root
-    group: root
-    mode: 0644
-
-- name: Install Ant installation directory
-  tags: ant
-  file:
-    path: /opt/apache/
-    state: directory
-    owner: root
-    group: root
-    mode: 0755
-
-- name: Install Ant
-  tags: ant
-  unarchive:
-    remote_src: yes
-    src: /tmp/downloads/apache-ant-1.9.7-bin.tar.gz
-    dest: /opt/apache
-
-- name: Build link to /usr/bin/ant
-  tags: ant
-  file:
-    state: link
-    force: true
-    src: /opt/apache/apache-ant-1.9.7/bin/ant
-    dest: /usr/bin/ant
-
 - name: Build fgsconfig
   command: >
-    ant -f /usr/share/tomcat/webapps/fedoragsearch/FgsConfig/fgsconfig-basic.xml
+    /opt/apache/ant/bin/ant -f /usr/share/tomcat/webapps/fedoragsearch/FgsConfig/fgsconfig-basic.xml
 
 - name: Copy ANT generated schema to schema.xml
   copy:
@@ -147,3 +115,14 @@
   service:
     name: "tomcat"
     state: "restarted"
+
+- name: Wait for tomcat to restart    
+  wait_for:
+    port: 8080
+    delay: 5
+
+- name: Reload Solr core
+  uri:
+    url: "http://localhost:8080/solr/admin/cores?wt=json&action=RELOAD&core=collection1"
+    method: "GET"
+    status_code: 200

--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -29,7 +29,7 @@
     dest: /tmp/downloads
     remote_src: yes
 
-- name: Create new directory for fedora
+- name: Create new directory for Fedora Solr
   file:
     path: "{{ fedora_home }}/solr"
     state: directory
@@ -94,10 +94,14 @@
       \1fgsconfig-basic-for-islandora.properties\2
 
 - name: Build fgsconfig
+  become: yes
+  become_user: tomcat
   command: >
     /opt/apache/ant/bin/ant -f /usr/share/tomcat/webapps/fedoragsearch/FgsConfig/fgsconfig-basic.xml
 
 - name: Copy ANT generated schema to schema.xml
+  become: yes
+  become_user: tomcat
   copy:
     src: /usr/share/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/conf/schema-4.2.0-for-fgs-2.7.xml
     dest: "{{ fedora_home }}/solr/collection1/conf/schema.xml"
@@ -111,19 +115,62 @@
     owner: "tomcat"
     group: "tomcat"
 
+- name: Get Discovery Garden basic Solr config
+  git:
+    dest: /tmp/downloads/basic-solr-config
+    repo: https://github.com/discoverygarden/basic-solr-config.git
+    version: 4.x
+    recursive: yes
+    force: yes
+    # We have to force this to make it idempotent because we'll be
+    # making changes to these files. Probably we should just fork the
+    # upstream code in the near future.
+
+- name: Adjust path to Tomcat in solr transforms
+  shell: |
+    cd /tmp/downloads/basic-solr-config/islandora_transforms
+    sed -i 's#/usr/local/fedora/tomcat#/var/lib/tomcat#g' ./*xslt
+
+- name: Get Discovery Garden gsearch extensions
+  git:
+    dest: /tmp/downloads/dgi_gsearch_extensions
+    repo: https://github.com/discoverygarden/dgi_gsearch_extensions.git
+
+- name: Get Discovery Garden gsearch extensions
+  shell: |
+    cd /tmp/downloads/dgi_gsearch_extensions
+    /opt/apache/maven/bin/mvn -q package
+  args:
+    creates: /tmp/downloads/dgi_gsearch_extensions/target/gsearch_extensions-0.1.1-jar-with-dependencies.jar
+
+- name: Deploy dgi_gsearch_extensions
+  become: true
+  become_user: tomcat
+  copy:
+    src: /tmp/downloads/dgi_gsearch_extensions/target/gsearch_extensions-0.1.1-jar-with-dependencies.jar
+    dest: /var/lib/tomcat/webapps/fedoragsearch/WEB-INF/lib
+    remote_src: yes
+
+- name: Deploy basic solr config
+  become: true
+  become_user: tomcat
+  shell: |
+     cp -v /tmp/downloads/basic-solr-config/conf/*  {{ fedora_home }}/solr/collection1/conf
+     cp -Rv /tmp/downloads/basic-solr-config/islandora_transforms /var/lib/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex
+
 - name: Restart tomcat
   service:
     name: "tomcat"
     state: "restarted"
 
-- name: Wait for tomcat to restart    
+- name: Wait for tomcat to restart
   wait_for:
     port: 8080
     delay: 10
 
 - name: Run gsearch updateindex from FoxmlFiles
   uri:
-    url: "http://localhost:8080/fedoragsearch/rest?operation=updateIndex&action=fromFoxmlFiles&value=" 
+    url: "http://localhost:8080/fedoragsearch/rest?operation=updateIndex&action=fromFoxmlFiles&value="
     method: "GET"
     status_code: 200
 

--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -52,6 +52,7 @@
 
 - name: Insert "fgsAdmin" user in fedora-users.xml
   blockinfile:
+    marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     dest: /usr/local/fedora/server/config/fedora-users.xml
     block: |
       <user name="fgsAdmin" password="fgsAdmin">

--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -119,7 +119,13 @@
 - name: Wait for tomcat to restart    
   wait_for:
     port: 8080
-    delay: 5
+    delay: 10
+
+- name: Run gsearch updateindex from FoxmlFiles
+  uri:
+    url: "http://localhost:8080/fedoragsearch/rest?operation=updateIndex&action=fromFoxmlFiles&value=" 
+    method: "GET"
+    status_code: 200
 
 - name: Reload Solr core
   uri:

--- a/tasks/java-tools.yml
+++ b/tasks/java-tools.yml
@@ -1,0 +1,59 @@
+---
+- name: Create Apache Project installation directory
+  file:
+    path: /opt/apache/
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Download Apache Project java tools
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: 0644
+  with_items: 
+    - url: "http://mirror.ox.ac.uk/sites/rsync.apache.org/ant/binaries/apache-ant-1.9.7-bin.tar.gz"
+      dest: "/tmp/downloads/apache-ant-1.9.7-bin.tar.gz"
+    - url: "http://mirror.cc.columbia.edu/pub/software/apache/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz"
+      dest: "/tmp/downloads/apache-maven-3.3.9-bin.tar.gz"
+
+- name: Install Apache Project java tools
+  unarchive:
+    remote_src: yes
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - src: "/tmp/downloads/apache-ant-1.9.7-bin.tar.gz"
+      dest: /opt/apache
+    - src:  "/tmp/downloads/apache-maven-3.3.9-bin.tar.gz"
+      dest: /opt/apache
+
+- name: Build standard links for Apache Java tools
+  file:
+    state: link
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - src: /opt/apache/apache-ant-1.9.7
+      dest: /opt/apache/ant
+    - src: /opt/apache/apache-maven-3.3.9
+      dest: /opt/apache/maven
+
+- name: Ensure /etc/profile.d/java-tools.sh exists
+  file:
+    path: /etc/profile.d/java-tools.sh
+    state: touch
+    mode: 0644
+    owner: root
+    group: wheel
+
+- name: Add Java tools to path
+  lineinfile:
+    state: present
+    dest: /etc/profile.d/java-tools.sh
+    line: "export PATH=/opt/apache/ant/bin:/opt/apache/maven/bin:$PATH"
+
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,10 @@
 - include: yum.yml
   sudo: yes
 
+- include: java-tools.yml
+  sudo: yes
+  tags:
+    - java-tools
 
 - include: gsearch.yml
   sudo: yes

--- a/templates/fgsconfig-basic-for-islandora.properties.j2
+++ b/templates/fgsconfig-basic-for-islandora.properties.j2
@@ -1,26 +1,26 @@
 configDisplayName=configProductionSolr
 gsearchBase=http://localhost:8080
 gsearchAppName=fedoragsearch
- 
+
 gsearchUser=fgsAdmin
 gsearchPass={{ gsearch_pass }}
 finalConfigPath=/usr/share/tomcat/webapps/fedoragsearch/WEB-INF/classes
- 
+
 logFilePath=/usr/local/fedora/server/logs
 logLevel=DEBUG
 namesOfRepositories=FgsRepos
- 
+
 namesOfIndexes=FgsIndex
 fedoraBase=http://localhost:8080
 fedoraAppName=fedora
- 
+
 fedoraUser=fedoraAdmin
 fedoraPass={{ fedora_pass }}
 fedoraVersion=3.8.1
- 
+
 objectStoreBase=/usr/local/fedora/data/objectStore
 indexEngine=Solr
 indexBase=http://localhost:8080/solr
- 
+
 indexDir=/usr/local/fedora/solr/collection1/data/index
 indexingDocXslt=foxmlToSolr

--- a/templates/tomcat.conf.j2
+++ b/templates/tomcat.conf.j2
@@ -47,7 +47,7 @@ SECURITY_MANAGER="false"
 # put your own definitions here
 # (i.e. LD_LIBRARY_PATH for some jdbc drivers)
 
-JAVA_OPTS="-Djava.awt.headless=true  -XX:+UseConcMarkSweepGC -Dkakadu.home=/opt/adore/djatoka/bin/Linux-x86-64 -Djava.library.path=/opt/adore/djatoka/lib/Linux-x86-64 -DLD_LIBRARY_PATH=/opt/adore/djatoka/lib/Linux-x86-64"
+JAVA_OPTS="-Djava.awt.headless=true -Xmx2048M -XX:+UseConcMarkSweepGC -Dkakadu.home=/opt/adore/djatoka/bin/Linux-x86-64 -Djava.library.path=/opt/adore/djatoka/lib/Linux-x86-64 -DLD_LIBRARY_PATH=/opt/adore/djatoka/lib/Linux-x86-64"
 
 
 


### PR DESCRIPTION
This PR:
- Parameterizes accounts and passwords
- Configures Drupal search permissions
- Gives Tomcat more RAM
- Fixes Solr file permissions
- Installs Solr config starter kit and extensions from DGI
- Installs maven and refactors Java tool installation to it's own file for future extraction into planned tomcat-java role
- Cleans up whitespace in GSearch properties file because the install is sensitive

This pull request DOES NOT include code to configure the Solr search UI. That must still be done manually in the Drupal admin interface. (coming soon)
## Motivation and Context

Establishes a baseline working Solr + GSearch that includes a good starter Solr config for common Islandora metadata.
## How Has This Been Tested?

Vagrant up with this role repeatedly results in working Islandora with working Solr search, including ingest of content.
