### PR TITLE
Use OU fork of DGI basic-solr-config.

### DIFF
--- a/tasks/gsearch.yml
+++ b/tasks/gsearch.yml
@@ -25,14 +25,14 @@
     timeout: 90
     dest: "/tmp/downloads/solr-4.2.0.tgz"
 
-- name: UnArchive Solr
+- name: Unarchive Solr
   unarchive:
     src: /tmp/downloads/solr-4.2.0.tgz
     dest: /tmp/downloads
     remote_src: yes
     copy: no
 
-- name: Create new directory for Fedora Solr
+- name: Create new directory for Fedora Solr index
   file:
     path: "{{ fedora_home }}/solr"
     state: directory
@@ -40,12 +40,13 @@
     owner: tomcat
     group: tomcat
 
-# Ansible copy doesn't support recusive copy of directories yet
 - name: Copy solr example files to the new directory
   become: yes
   become_user: tomcat
   shell: >
     cp --recursive -v /tmp/downloads/solr-4.2.0/example/solr/* "{{ fedora_home }}/solr/"
+
+# Ansible copy doesn't support recusive copy of directories yet
 
 - name: Copy solr to Tomcat Webapps Directory
   copy:
@@ -116,7 +117,7 @@
     backup: yes
     follow: yes
 
-- name: Add the Solr context file
+- name: Add the Solr context file to Tomcat
   template:
     src: "solr.xml.j2"
     dest: /usr/share/tomcat/conf/Catalina/localhost/solr.xml
@@ -126,18 +127,21 @@
 - name: Get Discovery Garden basic Solr config
   git:
     dest: /tmp/downloads/basic-solr-config
-    repo: https://github.com/discoverygarden/basic-solr-config.git
-    version: 4.x
+    repo: https://github.com/OULibraries/basic-solr-config.git
+    version: 4.x-oulib
     recursive: yes
     force: yes
+
     # We have to force this to make it idempotent because we'll be
-    # making changes to these files. Probably we should just fork the
-    # upstream code in the near future.
+    # making changes to files in a submodule with sed.
 
 - name: Configure location of Tomcat in Solr transforms
   shell: |
     cd /tmp/downloads/basic-solr-config/islandora_transforms
     sed -i 's#/usr/local/fedora/tomcat#/var/lib/tomcat#g' ./*xslt
+
+    # See!  We may fork this in the near future, but we're leaving it
+    # as-is for now so that it's easier to pull in upstream changes.
 
 - name: Get Discovery Garden gsearch extensions
   git:
@@ -159,11 +163,12 @@
     dest: /var/lib/tomcat/webapps/fedoragsearch/WEB-INF/lib
     remote_src: yes
 
-- name: Deploy basic Solr config
+- name: Deploy Solr config
   become: true
   become_user: tomcat
   shell: |
      cp -v /tmp/downloads/basic-solr-config/conf/*  {{ fedora_home }}/solr/collection1/conf
+     cp -v /tmp/downloads/basic-solr-config/foxmlToSolr.xslt /var/lib/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex
      cp -Rv /tmp/downloads/basic-solr-config/islandora_transforms /var/lib/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex
 
 - name: Restart Tomcat


### PR DESCRIPTION
Merging this PR will:
- Switch to OU fork of DGI `basic-solr-config`
- Install OU fork `foxmlToSolr.xslt` to  /var/lib/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex

It also adds a bit of documentaiton
## Motivation and Context

GSearch was attempting to extract metadata from binary files, which was too resource intensive and took too long. Our new version skips that. 
## How Has This Been Tested?

These are changes that we made manually in production.
Could probably use a little more testing, honestly. 
