### PR TITLE
move some manual post-install steps into configuration management

### DIFF
--- a/files/repo.make
+++ b/files/repo.make
@@ -18,6 +18,8 @@ projects[oembed][version] = "0.1-beta3"
 projects[token][version] = "1.6"
 projects[pathauto][version] = "1.3"
 projects[subpathauto][version] = "1.3"
+projects[configuration][version] = "2.0-alpha3"
+projects[xautoload][version] = "5.7"
 
 ; Themes
 projects[bootstrap][version] = "3.6"

--- a/files/repo_enable.php
+++ b/files/repo_enable.php
@@ -112,3 +112,6 @@ module_enable( array('ctools', 'link', 'themekey'));
 module_enable( array('oembed', 'oembed_provider', 'oembed_field'));
 module_enable( array('islandora_embed', 'ou_bagit_importer', 'islandora_internet_archive_bookreader_custom'));
 theme_enable( array('entity_iframe_theme', 'islandora_embed_theme'));
+
+# Configuration management
+module_enable( array('configuration', 'xautoload'));

--- a/tasks/islandora.yml
+++ b/tasks/islandora.yml
@@ -167,3 +167,14 @@
     dest: "/srv/{{islandora_site}}/drupal/sites/all/modules/islandora_internet_archive_bookreader/theme/theme.inc"
     owner: "apache"
     group: "apache"
+
+- name: Fetch OULib repository config
+  git:
+    dest: /srv/{{ islandora_site }}/default/files/config
+    repo: https://github.com/OULibraries/oulib_repo_config.git
+    recursive: yes
+    force: yes
+
+- name: Run config sync
+  command: >
+    /opt/php/bin/drush -r /srv/{{ islandora_site }}/drupal config-sync

--- a/tasks/islandora.yml
+++ b/tasks/islandora.yml
@@ -168,6 +168,11 @@
     owner: "apache"
     group: "apache"
 
+- name: Destroy config directory
+  file:
+    path: /srv/{{ islandora_site }}/default/files/config
+    state: absent
+
 - name: Fetch OULib repository config
   git:
     dest: /srv/{{ islandora_site }}/default/files/config


### PR DESCRIPTION
Build with drupal configuration module and pull state from another oulib repo

Motivation and Context
----------------------
This should eliminate pretty much all of the post-install configuration currently required for oulib islandora. It should close the following issues:
https://github.com/OULibraries/ansible-role-d7-islandora/issues/24
https://github.com/OULibraries/ansible-role-d7-islandora/issues/23

How Has This Been Tested?
-------------------------
underway
