### PR TITLE
Command arguments changed, switch to working version.

### DIFF
--- a/tasks/java-tools.yml
+++ b/tasks/java-tools.yml
@@ -22,7 +22,7 @@
 
 - name: Install Apache Project java tools
   unarchive:
-    remote_src: yes
+    copy: no
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
   with_items:


### PR DESCRIPTION
s/remote_src:yes/copy:no/

Motivation and Context
----------------------

We know `remote_src` used to work, but it is currently broken with the latest Ansible 2.1
Switching to older `copy` arg. 


How Has This Been Tested?
-------------------------
Strenuous hope!
