### PR TITLE
Update yum.yml

### DIFF
--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -8,3 +8,4 @@
     - libxml2
     - poppler-utils
     - lame
+    - ghostscript


### PR DESCRIPTION
Ghostscript is required by the PDF solution pack, and for PDF processing, generally. 